### PR TITLE
Fix nil __dirname crash and normalise_path pattern bug (issue #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,22 +41,23 @@ Below is the directory structure of the [tests](spec) in this package, all examp
 
 ```text
 spec
+├── _subdir
+│   ├── init.lua
+│   └── module.lua
 ├── fixture_three.lua
 └── unit
     ├── fixture_one.lua
     ├── fixture_two
-    │   ├── init.lua
-    │   └── two_dot_one.lua
+    │   ├── init.lua
+    │   └── two_dot_one.lua
     └── import_spec.lua
-
-3 directories, 5 files
 ```
 
 ```lua
 -- will import same as require
 local m = import('spec.unit.fixture_one')
 
--- will same as require with filepath separator
+-- will import same as require with filepath separator
 local m = import('spec/unit/fixture_one')
 
 -- will import relative to current directory
@@ -68,15 +69,28 @@ local m = import('fixture_one')
 -- will import relative to current directory with init.lua
 local m = import('./fixture_two')
 
--- will import relative to current directory with init.lua withouth ./
+-- will import relative to current directory with init.lua without ./
 local m = import('fixture_two/two_dot_one')
 
 -- will import relative to parent directory
 local m = import('../fixture_three')
 
+-- will import relative to parent directory with underscore-prefixed folder
+local m = import('../_subdir')
+
+-- will import relative to parent directory into a subfolder (slash notation)
+local m = import('../_subdir/module')
+
+-- will import relative to parent directory into a subfolder (dot notation)
+local m = import('../_subdir.module')
+
 -- will import relative to parent 2 up directories
 local m = import('../../import')
 ```
+
+> **Note:** Run scripts from the project root (e.g. `lua wiki/en/explora/script.lua`) so that
+> relative imports can resolve paths correctly. Running a script from its own directory
+> (e.g. `cd wiki/en/explora && lua script.lua`) limits `../` navigation to same-directory imports only.
 
 ## Development
 

--- a/import.lua
+++ b/import.lua
@@ -49,10 +49,10 @@ local function normalise_path(s)
       break
     end
   end
-  local to_trim = ''
-  if to_trim_index > -1 then to_trim = s:sub(1, to_trim_index) end
-  local to_return = s:gsub(to_trim, '')
-  return to_return
+  if to_trim_index > -1 and s:sub(to_trim_index, to_trim_index) == '/' then
+    return s:sub(to_trim_index + 1)
+  end
+  return s
 end
 
 ---The lua-import module provides a function,
@@ -62,7 +62,7 @@ end
 ---@param path any
 ---@return unknown
 function import(path)
-  local __dirname = debug.getinfo(2, 'S').source:sub(2):match('(.*' .. '/' .. ')')
+  local __dirname = debug.getinfo(2, 'S').source:sub(2):match('(.*' .. '/' .. ')') or './'
   local resolved_path = resolve_relative(path, __dirname)
   local normal_path = normalise_path(resolved_path)
   local require_arg = to_require_arg(normal_path)

--- a/lua-import-main-1.rockspec
+++ b/lua-import-main-1.rockspec
@@ -1,7 +1,7 @@
 rockspec_format = '3.0'
 package = 'lua-import'
 version = 'main-1' -- overwritten by git tag
-source = {url = 'git://github.com/yogeshlonkar/lua-import', tag = 'v0.1.1'}
+source = {url = 'git://github.com/yogeshlonkar/lua-import', tag = 'v0.1.2'}
 description = {
   summary = 'An import function to require modules with relative pattern',
   detailed = [[

--- a/spec/_subdir/init.lua
+++ b/spec/_subdir/init.lua
@@ -1,0 +1,1 @@
+return {name = '_subdir'}

--- a/spec/_subdir/module.lua
+++ b/spec/_subdir/module.lua
@@ -1,0 +1,1 @@
+return {name = '_subdir_module'}

--- a/spec/unit/deep/deep_spec.lua
+++ b/spec/unit/deep/deep_spec.lua
@@ -1,0 +1,23 @@
+require('busted')
+
+local import = require('import')
+
+describe('lua-import deep', function()
+  it('should import 2 levels up then into underscore subfolder', function()
+    local m = import('../../_subdir/module')
+    assert.no.Nil(m)
+    assert.Equal(m.name, '_subdir_module')
+  end)
+
+  it('should import 2 levels up then into underscore subfolder with dot notation', function()
+    local m = import('../../_subdir.module')
+    assert.no.Nil(m)
+    assert.Equal(m.name, '_subdir_module')
+  end)
+
+  it('should import 2 levels up then into underscore folder via init.lua', function()
+    local m = import('../../_subdir')
+    assert.no.Nil(m)
+    assert.Equal(m.name, '_subdir')
+  end)
+end)

--- a/spec/unit/import_spec.lua
+++ b/spec/unit/import_spec.lua
@@ -51,4 +51,30 @@ describe('lua-import', function()
     assert.Equal(type(m), 'function')
   end)
 
+  it('should import relative to parent directory with underscore folder', function()
+    local m = import('../_subdir')
+    assert.no.Nil(m)
+    assert.Equal(m.name, '_subdir')
+  end)
+
+  it('should import relative to parent directory into underscore subfolder', function()
+    local m = import('../_subdir/module')
+    assert.no.Nil(m)
+    assert.Equal(m.name, '_subdir_module')
+  end)
+
+  it('should import relative to parent directory into underscore subfolder with dot notation', function()
+    local m = import('../_subdir.module')
+    assert.no.Nil(m)
+    assert.Equal(m.name, '_subdir_module')
+  end)
+
+  it('should not crash when script is run from its own directory', function()
+    local cmd = 'cd spec/unit/standalone && lua -e "package.path = [=[../../../?.lua;]=] .. package.path" standalone.lua 2>&1'
+    local handle = io.popen(cmd)
+    local result = handle:read('*a')
+    handle:close()
+    assert.is.truthy(result:match('OK'), 'Expected OK but got: ' .. result)
+  end)
+
 end)

--- a/spec/unit/standalone/sibling.lua
+++ b/spec/unit/standalone/sibling.lua
@@ -1,0 +1,1 @@
+return {name = 'sibling'}

--- a/spec/unit/standalone/standalone.lua
+++ b/spec/unit/standalone/standalone.lua
@@ -1,0 +1,7 @@
+-- Simulates a script run as: lua standalone.lua (from its own directory)
+-- package.path must be set by the caller to find import.lua
+local import = require('import')
+local m = import('./sibling')
+assert(m ~= nil, 'import failed: got nil')
+assert(m.name == 'sibling', 'wrong name: ' .. tostring(m.name))
+print('OK')


### PR DESCRIPTION
Two bugs prevented relative imports from working in certain scenarios:

1. When a script is run from its own directory (e.g. `lua script.lua`), debug.getinfo returns no path prefix so __dirname was nil, causing a crash on any relative import. Fixed by falling back to './' when nil.

2. normalise_path used gsub with the common-prefix string as a Lua pattern, where '.' matches any character instead of a literal dot. This could silently corrupt the resolved path. Fixed by trimming with sub() at directory boundaries (/) only, avoiding pattern interpretation entirely.

Also adds tests for underscore-prefixed folders and the standalone-script case.

Closes #3 